### PR TITLE
Fix training data paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ def main():
     if args.train:
         print('Entrenando el modelo...')
         # Cargar datos de entrenamiento
-        X_train = pd.read_csv(DATA_DIR / 'X_test.csv')
-        y_train = pd.read_csv(DATA_DIR / 'y_test.csv')
+        X_train = pd.read_csv(DATA_DIR / 'X_train.csv')
+        y_train = pd.read_csv(DATA_DIR / 'y_train.csv')
         # Entrenar el modelo usando la función modular
         # Puedes ajustar el modelo aquí según tu pipeline real
         from sklearn.ensemble import RandomForestClassifier


### PR DESCRIPTION
## Summary
- load training data from `X_train.csv` and `y_train.csv`

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683f6af7ffdc832d9ec9fa401550cab1