### PR TITLE
Remove setup.py mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ startups-ml/
 ├── reports/               # Figuras y resultados finales
 ├── tests/                 # Pytest unit tests
 ├── app.py                 # API FastAPI
-├── setup.py               # Instalación editable
 ├── requirements.txt       # Dependencias en producción
 └── README.md              # ¡Estás aquí!
 ```


### PR DESCRIPTION
## Summary
- remove outdated reference to `setup.py` in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683f6af9a194832d95ea59fd2621ce74