### PR TITLE
Add missing load_model error test

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -64,3 +64,10 @@ def test_perform_bias_variance_analysis():
     assert isinstance(train_scores, list)
     assert isinstance(test_scores, list)
     assert best == 1
+
+
+def test_load_model_not_found(tmp_path):
+    """Verifica que load_model lance FileNotFoundError cuando el archivo no existe."""
+    nonexistent = tmp_path / "no_model.pkl"
+    with pytest.raises(FileNotFoundError):
+        load_model(nonexistent)


### PR DESCRIPTION
## Summary
- ensure load_model raises `FileNotFoundError` when the model file is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_683f6afcd250832db2dfd6a16dc4803f